### PR TITLE
bin/git-pause: pause untracked files

### DIFF
--- a/bin/git-pause
+++ b/bin/git-pause
@@ -7,4 +7,5 @@
 # of the current branch it will show up in git-log, you won't lose track of it.
 #
 # see-also: git-resume
+git add .
 git commit --no-verify -a -m"PAUSED: Use \`git resume\` to continue working."


### PR DESCRIPTION
Arguably a better way to make pauses. From my own experience, I often
do the `git add .` step manually, when I see that `git pause` didn't
catch untracked files related to my branch.